### PR TITLE
[plugins/prepackager/framework-conf] 修正版本号不是个位数的组件报 invalid version 错…

### DIFF
--- a/plugins/prepackager/framework-conf.js
+++ b/plugins/prepackager/framework-conf.js
@@ -25,7 +25,7 @@ function makeComponentModulesAlias(componentFile, map, ret) {
         //遍历component.json中的dependencies字段
         fis.util.map(json.dependencies, function(name, version){
             //必须使用明确的版本号
-            if(/^\d\./.test(version)){
+            if(/^\d+\./.test(version)){
                 //获取模块名，处理路径分隔符
                 var module_name = name.split('/').join('-');
                 //根据版本号找到模块目录


### PR DESCRIPTION
当组件的版本号不是个位数的时候(如 12.0.4 时)，framework-conf 第 28 行检测版本时报 invalid version 错误。